### PR TITLE
ensure three leading slashes on windows

### DIFF
--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mlflow
 Title: Interface to 'MLflow'
-Version: 1.12.1
+Version: 1.12.0
 Authors@R: c(
   person("Matei", "Zaharia", email = "matei@databricks.com", role = c("aut", "cre")),
   person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut")),

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -4,6 +4,7 @@ new_mlflow_client <- function(tracking_uri) {
 }
 
 new_mlflow_uri <- function(raw_uri) {
+  # fix file:///X:/D case
   # Special case 'databricks'
   if (identical(raw_uri, "databricks")) {
     raw_uri <- paste0("databricks", "://")
@@ -12,7 +13,8 @@ new_mlflow_uri <- function(raw_uri) {
   if (!grepl("://", raw_uri)) {
     raw_uri <- paste0("file://", raw_uri)
   }
-  parts <- strsplit(raw_uri, "://")[[1]]
+  pattern <- ifelse(is_windows(), ":///", "://")
+  parts <- strsplit(raw_uri, pattern)[[1]]
   structure(
     list(scheme = parts[1], path = parts[2]),
     class = c(paste("mlflow_", parts[1], sep = ""), "mlflow_uri")

--- a/mlflow/R/mlflow/R/tracking-globals.R
+++ b/mlflow/R/mlflow/R/tracking-globals.R
@@ -44,6 +44,20 @@ mlflow_set_tracking_uri <- function(uri) {
 mlflow_get_tracking_uri <- function() {
   .globals$tracking_uri %||% {
     env_uri <- Sys.getenv("MLFLOW_TRACKING_URI")
-    if (nchar(env_uri)) env_uri else paste("file://", fs::path_abs("mlruns"), sep = "")
+
+    if (nchar(env_uri)) {
+      env_uri
+    } else {
+      # don't use fs::path() because of https://github.com/r-lib/fs/issues/245
+      paste(
+        "file://",
+        fs::path_abs("mlruns"),
+        sep = ifelse(is_windows(), "/", "")
+      )
+    }
   }
+}
+
+is_windows <- function() {
+  identical(.Platform$OS.type, "windows")
 }


### PR DESCRIPTION
because fs::path_abs() retuns D:/x/y/y, whereas on unix, it returns /User/x/y/y. So on windows, paste("file://", fs::path_abs(...)) returns an invalid URI scheme.

https://en.wikipedia.org/wiki/File_URI_scheme
Signed-off-by: Lorenz Walthert <lorenz.walthert@icloud.com>

